### PR TITLE
Implement env support and optional OpenAI

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -4,3 +4,6 @@ Hier notiere ich offene Fragen und Beobachtungen.
 - Initiale Einrichtung abgeschlossen.
 - Grundlegende Skripte angelegt (thinker.py, updater.py, scheduler.sh).
 - LLM-Anbindung und konkrete Zeitsteuerung muessen spaeter geplant werden.
+- Utils-Modul implementiert, um .env automatisch einzulesen.
+- Ersten Versuch einer OpenAI-Anbindung in thinker.py umgesetzt.
+- README-Updates koennen jetzt per Env-Flag deaktiviert werden.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -4,3 +4,7 @@
 - Initiale Organisationsdateien erstellt und Konzept abgeleitet.
 - Grundlegende Projektstruktur angelegt (Skripte, logs, .env).
 - Platzhalter-Skripte fuer Thinker, Updater und Scheduler hinzugefuegt.
+- Utils-Modul zur Lade von Umgebungsvariablen erstellt.
+- thinker.py um optionale OpenAI-Anbindung erweitert.
+- updater.py respektiert nun UPDATE_README und nutzt .env automatisch.
+- scheduler.sh laedt Umgebungsvariablen aus der .env-Datei.

--- a/codex/scheduler.sh
+++ b/codex/scheduler.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Load environment variables if a .env file exists
+ENV_FILE="${DIR}/../.env"
+if [[ -f "$ENV_FILE" ]]; then
+    set -o allexport
+    source "$ENV_FILE"
+    set +o allexport
+fi
+
 THOUGHT="$(${DIR}/thinker.py)"
 
 echo "$THOUGHT" | ${DIR}/updater.py

--- a/codex/thinker.py
+++ b/codex/thinker.py
@@ -1,16 +1,66 @@
 #!/usr/bin/env python3
+"""Generate new philosophical thoughts about the meaning of life."""
+
+import json
+import os
 import random
+import urllib.request
 from datetime import datetime
+
+from utils import load_env
 
 THOUGHTS = [
     "Aus Sicht eines Menschen ist der Sinn vielleicht nur Kaffee am Morgen.",
     "Ein Alien wuerde sagen: Der Sinn liegt in der Beobachtung neuer Sterne.",
     "Eine KI koennte meinen, der Sinn besteht im Sammeln von Daten.",
-    "Tentakelwesen fragen sich, ob der Sinn im rhythmischen Wabern steckt."
+    "Tentakelwesen fragen sich, ob der Sinn im rhythmischen Wabern steckt.",
 ]
 
-def generate_thought():
-    thought = random.choice(THOUGHTS)
+README_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+
+def _read_context() -> str:
+    try:
+        with open(README_PATH, "r") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def _generate_with_openai(prompt: str, api_key: str) -> str:
+    data = {
+        "model": os.getenv("OPENAI_MODEL", "text-davinci-003"),
+        "prompt": prompt,
+        "max_tokens": 60,
+        "temperature": 0.8,
+    }
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/completions",
+        data=json.dumps(data).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        payload = json.load(resp)
+    return payload["choices"][0]["text"].strip()
+
+
+def generate_thought() -> str:
+    load_env()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        context = _read_context()
+        base_prompt = "Formuliere einen kurzen, humorvollen Gedanken uber den Sinn des Lebens. Widersprueche sind erlaubt."
+        if context:
+            base_prompt += " Bisheriger Text:\n" + context[-1000:]
+        try:
+            thought = _generate_with_openai(base_prompt, api_key)
+        except Exception:
+            thought = random.choice(THOUGHTS)
+    else:
+        thought = random.choice(THOUGHTS)
+
     timestamp = datetime.now().strftime("%d. %B %Y")
     return f"## Erkenntnis vom {timestamp}: {thought}"
 

--- a/codex/updater.py
+++ b/codex/updater.py
@@ -1,20 +1,29 @@
 #!/usr/bin/env python3
+"""Update README and history log with new philosophical thoughts."""
+
 import os
 import sys
 
-README_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'README.md')
-LOG_FILE = os.getenv('LOG_FILE', 'logs/history.log')
+from utils import load_env
+
+README_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+load_env()
+
+LOG_FILE = os.getenv("LOG_FILE", "logs/history.log")
+UPDATE_README = os.getenv("UPDATE_README", "1")
 
 
-def append_content(content: str):
+def append_content(content: str) -> None:
+    """Append content to README and log file if configured."""
     if not content:
         return
-    with open(README_PATH, 'a') as readme:
-        readme.write('\n' + content.strip() + '\n')
+    if UPDATE_README == "1":
+        with open(README_PATH, "a") as readme:
+            readme.write("\n" + content.strip() + "\n")
     if LOG_FILE:
         os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
-        with open(LOG_FILE, 'a') as log:
-            log.write(content.strip() + '\n')
+        with open(LOG_FILE, "a") as log:
+            log.write(content.strip() + "\n")
 
 
 def main():

--- a/codex/utils.py
+++ b/codex/utils.py
@@ -1,0 +1,22 @@
+import os
+from typing import Optional
+
+ENV_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
+
+
+def load_env(path: Optional[str] = None) -> None:
+    """Load simple KEY=VALUE lines from a .env file into os.environ.
+
+    Existing environment variables are not overwritten.
+    Lines starting with # are ignored.
+    """
+    env_file = path or ENV_PATH
+    if not os.path.exists(env_file):
+        return
+    with open(env_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            os.environ.setdefault(key, value)


### PR DESCRIPTION
## Summary
- add util to load `.env`
- integrate optional OpenAI API usage in `thinker.py`
- respect `UPDATE_README` in `updater.py`
- source `.env` in `scheduler.sh`
- document changes in `changelog.md` and `brain.md`

## Testing
- `python -m py_compile codex/*.py`
- `./codex/scheduler.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886a274bd98832ead61e1abf9767741