### PR TITLE
Update thinker timestamp formatting

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -8,3 +8,4 @@ Hier notiere ich offene Fragen und Beobachtungen.
 - Ersten Versuch einer OpenAI-Anbindung in thinker.py umgesetzt.
 - README-Updates koennen jetzt per Env-Flag deaktiviert werden.
 - Log-Datei landete zunaechst im falschen Verzeichnis, Standardpfad korrigiert.
+- Zeitstempel in thinker.py liefern nun deutsche Monatsnamen.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -9,3 +9,5 @@
 - updater.py respektiert nun UPDATE_README und nutzt .env automatisch.
 - scheduler.sh laedt Umgebungsvariablen aus der .env-Datei.
 - history.log wird nun immer im Projektstamm geschrieben.
+- thinker.py formatiert Zeitstempel nun mit deutschen Monatsnamen.
+- Dokumentation zu Zeitstempeln aktualisiert.

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -15,6 +15,7 @@
 ### updater.py
 - Ergaenzt die README.md um den neuen Beitrag.
 - Fuegt Zeitstempel hinzu und haelt den humorvollen Stil bei.
+- Zeitstempel nutzen deutsche Monatsnamen.
 - Optional: Append in `logs/history.log`.
 
 ### scheduler.sh

--- a/codex/thinker.py
+++ b/codex/thinker.py
@@ -7,6 +7,26 @@ import random
 import urllib.request
 from datetime import datetime
 
+GERMAN_MONTHS = [
+    "Januar",
+    "Februar",
+    "Maerz",
+    "April",
+    "Mai",
+    "Juni",
+    "Juli",
+    "August",
+    "September",
+    "Oktober",
+    "November",
+    "Dezember",
+]
+
+
+def _format_timestamp(dt: datetime) -> str:
+    """Return a German formatted date string."""
+    return f"{dt.day}. {GERMAN_MONTHS[dt.month - 1]} {dt.year}"
+
 from utils import load_env
 
 THOUGHTS = [
@@ -61,7 +81,7 @@ def generate_thought() -> str:
     else:
         thought = random.choice(THOUGHTS)
 
-    timestamp = datetime.now().strftime("%d. %B %Y")
+    timestamp = _format_timestamp(datetime.now())
     return f"## Erkenntnis vom {timestamp}: {thought}"
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add German month support to timestamps
- document timestamp format in docs
- note change in changelog and brain

## Testing
- `python3 -m py_compile codex/thinker.py codex/updater.py codex/utils.py`
- `python3 codex/thinker.py`

------
https://chatgpt.com/codex/tasks/task_e_6886a8471cec832e82c0d26e0fcd61a4